### PR TITLE
Don't trim trailing slashes from the end of canonical URLs

### DIFF
--- a/src/mushroom/Mushroom.php
+++ b/src/mushroom/Mushroom.php
@@ -173,6 +173,6 @@ class Mushroom
      */
     private function cleanUrl($url)
     {
-        return trim($url, '/');
+        return $url;
     }
 }


### PR DESCRIPTION
Trailing slashes are usually part of the unique signature of urls and how they are explicitly set.  Removing them could cause confusion when trying to keep track of sets of unique urls
