### PR TITLE
Stop Removing trailing slashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,10 @@ Use composer
 
 ```composer require willwashburn/mushroom```
 
-Alternatively, add ```"willwashburn/mushroom": "~1.1.0"``` to your composer.json
+Alternatively, add ```"willwashburn/mushroom": ">=2.0.0"``` to your composer.json
 
 ## Change Log
+- v2.0.0 - **Breaking change**: stopped removing slashes from the end of urls
 - v1.1.0 - Add ability to find canonical url from tags in body of returned page
 - v1.0.0 - Expand multiple links using multi_curl_* for faster responses
 - v0.0.2 - Basic link expanding using curl

--- a/src/mushroom/Mushroom.php
+++ b/src/mushroom/Mushroom.php
@@ -72,7 +72,7 @@ class Mushroom
      */
     private function batchFollow($urls, array $options)
     {
-        if ( empty($urls) ) {
+        if (!$urls) {
             return [];
         }
 

--- a/src/mushroom/Mushroom.php
+++ b/src/mushroom/Mushroom.php
@@ -39,7 +39,7 @@ class Mushroom
      * @param       $urls
      * @param array $options
      *
-     * @return string
+     * @return string|array
      */
     public function canonical($urls, array $options = [])
     {
@@ -53,7 +53,7 @@ class Mushroom
      * @param       $urls
      * @param array $options an array of options
      *
-     * @return string
+     * @return string|array
      */
     public function expand($urls, array $options = [])
     {
@@ -114,7 +114,7 @@ class Mushroom
      * @param $url
      * @param $options
      *
-     * @return mixed
+     * @return string
      */
     private function followToLocation($url, array $options)
     {

--- a/src/mushroom/Mushroom.php
+++ b/src/mushroom/Mushroom.php
@@ -23,7 +23,7 @@ class Mushroom
     /**
      * Mushroom constructor.
      *
-     * @param Curl|null $curl
+     * @param Curl|null      $curl
      * @param Canonical|null $canonical
      */
     public function __construct(Curl $curl = null, Canonical $canonical = null)
@@ -159,20 +159,11 @@ class Mushroom
             $url = $this->canonical->url($this->curl->curl_multi_getcontent($ch));
 
             if ( $url ) {
-                return $this->cleanUrl($url);
+                return $url;
             }
         }
 
-        return $this->cleanUrl($this->curl->curl_getinfo($ch, CURLINFO_EFFECTIVE_URL));
+        return $this->curl->curl_getinfo($ch, CURLINFO_EFFECTIVE_URL);
     }
 
-    /**
-     * @param $url
-     *
-     * @return string
-     */
-    private function cleanUrl($url)
-    {
-        return trim($url, '/');
-    }
 }

--- a/tests/ExpandLinksTest.php
+++ b/tests/ExpandLinksTest.php
@@ -46,7 +46,7 @@ class ExpandLinkTest extends PHPUnit_Framework_TestCase
     {
         return [
             ['http://bit.ly/1bdDlXc', 'http://www.google.com/'], // shortened
-            ['http://www.google.com', 'http://www.google.com/'], // nothing
+            ['http://www.google.com/', 'http://www.google.com/'], // nothing
             ['https://jigsaw.w3.org/HTTP/300/301.html', 'https://jigsaw.w3.org/HTTP/300/Overview.html'], // 301 redirect
             ['http://blog.tailwindapp.com/pinterest-smart-feed-pin-visibility/', 'http://blog.tailwindapp.com/pinterest-smart-feed-pin-visibility/'] // trailing slash
         ];

--- a/tests/ExpandLinksTest.php
+++ b/tests/ExpandLinksTest.php
@@ -45,9 +45,10 @@ class ExpandLinkTest extends PHPUnit_Framework_TestCase
     public function linksProvider()
     {
         return [
-            ['http://bit.ly/1bdDlXc', 'http://www.google.com'], // shortened
-            ['http://www.google.com', 'http://www.google.com'], // nothing
-            ['https://jigsaw.w3.org/HTTP/300/301.html', 'https://jigsaw.w3.org/HTTP/300/Overview.html'] // 301 redirect
+            ['http://bit.ly/1bdDlXc', 'http://www.google.com/'], // shortened
+            ['http://www.google.com', 'http://www.google.com/'], // nothing
+            ['https://jigsaw.w3.org/HTTP/300/301.html', 'https://jigsaw.w3.org/HTTP/300/Overview.html'], // 301 redirect
+            ['http://blog.tailwindapp.com/pinterest-smart-feed-pin-visibility/', 'http://blog.tailwindapp.com/pinterest-smart-feed-pin-visibility/'] // trailing slash
         ];
     }
 
@@ -91,7 +92,8 @@ class ExpandLinkTest extends PHPUnit_Framework_TestCase
     public function canonicalLinksProvider()
     {
         return [
-            ['http://blog.tailwindapp.com/tailwind-publisher-2-0/?foo=foobar', 'http://blog.tailwindapp.com/tailwind-publisher-2-0'],
+            ['http://blog.tailwindapp.com/tailwind-publisher-2-0/?foo=foobar', 'http://blog.tailwindapp.com/tailwind-publisher-2-0/'],
+            ['http://blog.tailwindapp.com/tailwind-publisher-2-0?foo=foobar', 'http://blog.tailwindapp.com/tailwind-publisher-2-0/'],
             ['http://www.willwashburn.com/?foo', 'http://www.willwashburn.com/?foo'], //no tags
         ];
     }


### PR DESCRIPTION
This would stop removing the slash in favor of letting people do that downstream if they want to. We should consider foo.com/ and foo.com to be different urls.

Since this breaks how it used to work, we’ll need to update the major version number.
