### PR TITLE
Follow http-refresh html meta tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ php:
   - '5.5'
   - '5.6'
   - '7.0'
-  - hhvm
   - nightly
   
 install:

--- a/README.md
+++ b/README.md
@@ -28,9 +28,10 @@ Use composer
 
 ```composer require willwashburn/mushroom```
 
-Alternatively, add ```"willwashburn/mushroom": "~2.3"``` to your composer.json
+Alternatively, add ```"willwashburn/mushroom": "~2.4"``` to your composer.json
 
 ## Change Log
+- v2.4.0 - Follow http-refresh html meta tags
 - v2.3.0 - Ensure that canonical urls have a host
 - v2.2.0 - Ensure that canonical urls have a scheme
 - v2.1.1 - Remove CURLOPT_NOBODY from defaults

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,12 @@
   },
   "require-dev": {
     "mockery/mockery": "~0.9",
-    "phpunit/phpunit": "~4.0"
+    "phpunit/phpunit": "~4.0",
+    "squizlabs/php_codesniffer": "3.*"
+  },
+  "scripts": {
+    "fix": "vendor/bin/phpcbf src/ tests/*.php --standard=PSR2",
+    "test": "vendor/bin/phpcs src/ --standard=PSR2 && vendor/bin/phpunit"
   },
   "autoload": {
     "classmap": [

--- a/composer.json
+++ b/composer.json
@@ -23,13 +23,12 @@
     "resolver",
     "resolve url"
   ],
-  "github": "https://github.com/willwashburn/mushroom",
   "homepage": "https://github.com/willwashburn/mushroom",
   "license": "MIT",
   "require": {
     "php": ">=5.4.0",
-    "willwashburn/canonical": ">=1.1",
-    "willwashburn/curl": ">=1.0"
+    "willwashburn/canonical": "~2",
+    "willwashburn/curl": "~1"
   },
   "require-dev": {
     "mockery/mockery": "~0.9",

--- a/src/mushroom/Mushroom.php
+++ b/src/mushroom/Mushroom.php
@@ -140,6 +140,7 @@ class Mushroom
 
             // Some hosts don't respond well if you're a bot
             // so we lie
+            // @codingStandardsIgnoreLine
             CURLOPT_USERAGENT      => 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:45.0) Gecko/20100101 Firefox/45.0',
             CURLOPT_AUTOREFERER    => true,
         ];
@@ -163,12 +164,10 @@ class Mushroom
     private function getUrlFromHandle($ch, array $options)
     {
         if (array_key_exists('canonical', $options) && $options['canonical'] === true) {
-
             // Canonical will read tags to find rel=canonical and og tags
             $url = $this->canonical->url($this->curl->curl_multi_getcontent($ch));
 
             if ($url) {
-
                 // Canonical urls should have a scheme and a host;
                 // if they do not, we'll use the effective url from the curl
                 // request to determine what it should be
@@ -193,7 +192,7 @@ class Mushroom
                 }
 
                 // Create a string of the url again
-                return $this->unparse_url($parsed);
+                return $this->unparseUrl($parsed);
             }
         }
 
@@ -207,7 +206,7 @@ class Mushroom
      *
      * @return string
      */
-    private function unparse_url($parsed_url)
+    private function unparseUrl($parsed_url)
     {
         $scheme   = isset($parsed_url['scheme']) ? $parsed_url['scheme'] . '://' : '';
         $host     = isset($parsed_url['host']) ? $parsed_url['host'] : '';

--- a/tests/ExpandLinksTest.php
+++ b/tests/ExpandLinksTest.php
@@ -46,8 +46,8 @@ class ExpandLinkTest extends PHPUnit_Framework_TestCase
             ['http://bit.ly/1bdDlXc', 'https://www.google.com/?gws_rd=ssl'], // shortened
             ['https://www.google.com/', 'https://www.google.com/'], // nothing
             ['https://jigsaw.w3.org/HTTP/300/301.html', 'https://jigsaw.w3.org/HTTP/300/Overview.html'], // 301 redirect
-            ['http://blog.tailwindapp.com/pinterest-smart-feed-pin-visibility/', 'http://blog.tailwindapp.com/pinterest-smart-feed-pin-visibility/'], // trailing slash
-            ['http://wp.me//p7gsPW-Gi', 'http://traveltalesoflife.com/2014/06/06/travel-theme-unexpected-the-co-ed-turkish-bath/'],
+            ['http://blog.tailwindapp.com/pinterest-smart-feed-pin-visibility/', 'https://blog.tailwindapp.com/pinterest-smart-feed-pin-visibility/'], // trailing slash
+            ['http://wp.me//p7gsPW-Gi', 'https://traveltalesoflife.com/travel-theme-unexpected-the-co-ed-turkish-bath/'],
         ];
     }
 
@@ -86,10 +86,10 @@ class ExpandLinkTest extends PHPUnit_Framework_TestCase
     public function canonicalLinksProvider()
     {
         return [
-            ['http://blog.tailwindapp.com/tailwind-publisher-2-0/?foo=foobar', 'http://blog.tailwindapp.com/tailwind-publisher-2-0/'],
-            ['http://blog.tailwindapp.com/tailwind-publisher-2-0?foo=foobar', 'http://blog.tailwindapp.com/tailwind-publisher-2-0/'],
+            ['http://blog.tailwindapp.com/tailwind-publisher-2-0/?foo=foobar', 'https://blog.tailwindapp.com/tailwind-publisher-2-0/'],
+            ['http://blog.tailwindapp.com/tailwind-publisher-2-0?foo=foobar', 'https://blog.tailwindapp.com/tailwind-publisher-2-0/'],
             ['http://www.willwashburn.com/?foo', 'http://willwashburn.com/?foo'], //no tags
-            ['http://www.practicallyfunctional.com/so-creative-18-delicious-game-day-appetizers/', 'http://www.practicallyfunctional.com/so-creative-18-delicious-game-day-appetizers/'], // protocol issues
+            ['http://www.practicallyfunctional.com/so-creative-18-delicious-game-day-appetizers/', 'https://www.practicallyfunctional.com/so-creative-18-delicious-game-day-appetizers/'], // protocol issues
             ['https://vimeo.com/63823593', 'https://vimeo.com/63823593'], // canonical is relative
         ];
     }
@@ -108,11 +108,11 @@ class ExpandLinkTest extends PHPUnit_Framework_TestCase
                ->shouldReceive('curl_getinfo')->getMock()
                ->shouldReceive('curl_setopt_array')
                ->with(M::any(), M::on(function ($arg) use ($expected_curl_opts) {
-                   foreach (array_keys($expected_curl_opts) as $key) {
-                       if ($arg[$key] != $expected_curl_opts[$key]) {
-                           return false;
-                       }
-                   }
+                foreach (array_keys($expected_curl_opts) as $key) {
+                    if ($arg[$key] != $expected_curl_opts[$key]) {
+                        return false;
+                    }
+                }
 
                    return true;
                }))

--- a/tests/ExpandLinksTest.php
+++ b/tests/ExpandLinksTest.php
@@ -120,6 +120,6 @@ class ExpandLinkTest extends PHPUnit_Framework_TestCase
 
         $mushroom = new \Mushroom\Mushroom($curl);
 
-        $mushroom->expand('http://www.foobar.com', ['curl_opts' => $expected_curl_opts]);
+        $mushroom->expand('http://www.foobar.com', $expected_curl_opts);
     }
 }

--- a/tests/ExpandLinksTest.php
+++ b/tests/ExpandLinksTest.php
@@ -48,6 +48,7 @@ class ExpandLinkTest extends PHPUnit_Framework_TestCase
             ['https://jigsaw.w3.org/HTTP/300/301.html', 'https://jigsaw.w3.org/HTTP/300/Overview.html'], // 301 redirect
             ['http://blog.tailwindapp.com/pinterest-smart-feed-pin-visibility/', 'https://blog.tailwindapp.com/pinterest-smart-feed-pin-visibility/'], // trailing slash
             ['http://wp.me//p7gsPW-Gi', 'https://traveltalesoflife.com/travel-theme-unexpected-the-co-ed-turkish-bath/'],
+            ['https://www.rapidtables.com/web/dev/redirect/html-redirect-test.html','https://www.rapidtables.com/web/dev/html-redirect.html'],
         ];
     }
 
@@ -91,6 +92,9 @@ class ExpandLinkTest extends PHPUnit_Framework_TestCase
             ['http://www.willwashburn.com/?foo', 'http://willwashburn.com/?foo'], //no tags
             ['http://www.practicallyfunctional.com/so-creative-18-delicious-game-day-appetizers/', 'https://www.practicallyfunctional.com/so-creative-18-delicious-game-day-appetizers/'], // protocol issues
             ['https://vimeo.com/63823593', 'https://vimeo.com/63823593'], // canonical is relative
+
+            /// http-refresh links
+            ['https://www.rapidtables.com/web/dev/redirect/html-redirect-test.html','https://www.rapidtables.com/web/dev/html-redirect.html'],
         ];
     }
 
@@ -103,8 +107,10 @@ class ExpandLinkTest extends PHPUnit_Framework_TestCase
         $curl
             = M::mock('\WillWashburn\Curl')
                ->shouldReceive('curl_init')->getMock()
-               ->shouldReceive('curl_exec')->getMock()
-               ->shouldReceive('curl_close')->getMock()
+               ->shouldReceive('curl_multi_init')->getMock()
+               ->shouldReceive('curl_multi_add_handle')->getMock()
+               ->shouldReceive('curl_multi_exec')->getMock()
+               ->shouldReceive('curl_multi_close')->getMock()
                ->shouldReceive('curl_getinfo')->getMock()
                ->shouldReceive('curl_setopt_array')
                ->with(M::any(), M::on(function ($arg) use ($expected_curl_opts) {


### PR DESCRIPTION
Some sites will redirect to the final destination using an html tag that tells the browser to redirect. 

```html
<meta http-equiv="refresh" content="5; url=http://example.com/">
```

would tell the browser to go to http://example.com. These changes ensure that mushroom follows those all the way through.