### PR TITLE
Add `addJsRedirectDomain()` method.

### DIFF
--- a/src/mushroom/Mushroom.php
+++ b/src/mushroom/Mushroom.php
@@ -58,6 +58,20 @@ class Mushroom
     }
 
     /**
+     * Add a domain to JS Redirect Domains array.
+     *
+     * @param string $domain
+     *
+     * @return $this
+     */
+    public function addJsRedirectDomain(string $domain)
+    {
+        $this->jsRedirectDomains[] = $domain;
+
+        return $this;
+    }
+    
+    /**
      * Expands to the canonical url, according to the 'rel=canonical' tag
      * at the end of all redirects for a given link.
      *

--- a/src/mushroom/Mushroom.php
+++ b/src/mushroom/Mushroom.php
@@ -64,13 +64,23 @@ class Mushroom
      *
      * @return $this
      */
-    public function addJsRedirectDomain(string $domain)
+    public function addJsRedirectDomain($domain)
     {
         $this->jsRedirectDomains[] = $domain;
 
         return $this;
     }
-    
+
+    /**
+     * Get JS Redirect Domains.
+     *
+     * @return array
+     */
+    public function getJsRedirectDomains()
+    {
+        return $this->jsRedirectDomains;
+    }
+
     /**
      * Expands to the canonical url, according to the 'rel=canonical' tag
      * at the end of all redirects for a given link.

--- a/tests/ExpandLinksTest.php
+++ b/tests/ExpandLinksTest.php
@@ -177,4 +177,14 @@ class ExpandLinkTest extends PHPUnit_Framework_TestCase
 
         $this->assertFalse($mushroom->getCachedHtml('https://www.tailwindapp.com'));
     }
+
+    public function test_add_js_redirect_domain()
+    {
+        $jsRedirectDomain = 'google.com';
+
+        $mushroom = new Mushroom();
+        $mushroom->addJsRedirectDomain($jsRedirectDomain);
+
+        $this->assertArrayHasKey($jsRedirectDomain, $mushroom->getJsRedirectDomains());
+    }
 }


### PR DESCRIPTION
This will let us add our own domains to the JS Redirect Domains list.

I was testing this with a domain which has a JS redirect for which I've also proposed a regex improvement here https://github.com/willwashburn/canonical/pull/2

It would be great if this gets merged. Thanks!