### PR TITLE
Fix unit test failure.

### DIFF
--- a/tests/ExpandLinksTest.php
+++ b/tests/ExpandLinksTest.php
@@ -185,6 +185,6 @@ class ExpandLinkTest extends PHPUnit_Framework_TestCase
         $mushroom = new Mushroom();
         $mushroom->addJsRedirectDomain($jsRedirectDomain);
 
-        $this->assertArrayHasKey($jsRedirectDomain, $mushroom->getJsRedirectDomains());
+        $this->assertContains($jsRedirectDomain, $mushroom->getJsRedirectDomains());
     }
 }


### PR DESCRIPTION
The previous method fails and I realized after re-checking it should check for the value, not for the key in the array.

Weirdly it was working fine on my local env. somehow. This should fix that. Please merge this. Thanks!